### PR TITLE
Add bun.lockb ignore for Bun JavaScript projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -396,3 +396,6 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
+
+# Bun lockfile
+bun.lockb


### PR DESCRIPTION
This PR will change:
- .gitignore

What will this PR change/add:
- Adds support for bun.lockb file to gitignore